### PR TITLE
Prevent segfault in gctx_cleanup()

### DIFF
--- a/pam_saml.c
+++ b/pam_saml.c
@@ -324,7 +324,7 @@ pam_global_context_init(pamh, ac, av)
 	return gctx;
 
 cleanup:
-	gctx_cleanup(pamh, &gctx, error);
+	gctx_cleanup(pamh, gctx, error);
 	return NULL;
 }
 


### PR DESCRIPTION
Prevent segfault in gctx_cleanup()
    
     #0  0x00007ffff6f6d634 in __GI___libc_free (mem=0x7fffdb142094) at
     malloc.c:2945
     #1  0x00007ffff119b9c5 in gctx_cleanup (pamh=<optimized out>,
     data=0x7fffdb141cb8, error=<optimized out>)
         at pam_saml.c:148
     #2  0x00007ffff119c2ad in pam_global_context_init (av=<optimized out>,
         ac=<optimized out>, pamh=0x150de80)
         at pam_saml.c:327
     #3  pam_sm_authenticate (pamh=0x150de80, flags=<optimized out>,
         ac=<optimized out>, av=<optimized out>)
         at pam_saml.c:449
     #4  0x00007fffefef6fcf in ?? () from /lib/x86_64-linux-gnu/libpam.so.0
     #5  0x00007fffefef685d in pam_authenticate () from
         /lib/x86_64-linux-gnu/libpam.so.0
     #6  0x00007ffff0106615 in ?? () from
         /usr/lib/python2.7/dist-packages/PAMmodule.so
     #7  0x00000000004c9196 in call_function (oparg=<optimized out>,
         pp_stack=<optimized out>) at ../Python/ceval.c:4033
     #8  PyEval_EvalFrameEx () at ../Python/ceval.c:2679
     #9  0x00000000004e4518 in PyEval_EvalCodeEx (closure=<optimized out>,
         defcount=<optimized out>,
             defs=<optimized out>, kwcount=<optimized out>, kws=<optimized
             out>, argcount=<optimized out>,
                 args=<optimized out>, locals=<optimized out>,
                 globals=<optimized out>, co=<optimized out>)
         at ../Python/ceval.c:3265
     #10 function_call.lto_priv () at ../Objects/funcobject.c:526
     #11 0x00000000004ccd09 in PyObject_Call (kw=<optimized out>,
         arg=<optimized out>, func=<optimized out>)
         at ../Objects/abstract.c:2529
     #12 ext_do_call (nk=<optimized out>, na=<optimized out>,
         flags=<optimized out>, pp_stack=<optimized out>,
             func=<optimized out>) at ../Python/ceval.c:4346
     #13 PyEval_EvalFrameEx () at ../Python/ceval.c:2718
     #14 0x00000000004e4518 in PyEval_EvalCodeEx (closure=<optimized out>,
             defcount=<optimized out>,
                 defs=<optimized out>, kwcount=<optimized out>,
                 kws=<optimized out>, argcount=<optimized out>,
                     args=<optimized out>, locals=<optimized out>,
                     globals=<optimized out>, co=<optimized out>)
         at ../Python/ceval.c:3265
     #15 function_call.lto_priv () at ../Objects/funcobject.c:526
     #16 0x00000000004ccd09 in PyObject_Call (kw=<optimized out>,
         arg=<optimized out>, func=<optimized out>)
         at ../Objects/abstract.c:2529
     #17 ext_do_call (nk=<optimized out>, na=<optimized out>,
         flags=<optimized out>, pp_stack=<optimized out>,
             func=<optimized out>) at ../Python/ceval.c:4346
     #18 PyEval_EvalFrameEx () at ../Python/ceval.c:2718
     #19 0x00000000004e4518 in PyEval_EvalCodeEx (closure=<optimized out>,
             defcount=<optimized out>,
                 defs=<optimized out>, kwcount=<optimized out>,
                 kws=<optimized out>, argcount=<optimized out>,
                     args=<optimized out>, locals=<optimized out>,
                     globals=<optimized out>, co=<optimized out>)
         at ../Python/ceval.c:3265
     #20 function_call.lto_priv () at ../Objects/funcobject.c:526
     #21 0x0000000000502ab8 in PyObject_Call (kw=<optimized out>,
         arg=<optimized out>, func=<optimized out>)
         at ../Objects/abstract.c:2529
     #22 instancemethod_call.lto_priv () at ../Objects/classobject.c:2602
     #23 0x00000000004b32de in PyObject_Call () at ../Objects/abstract.c:2529
     #24 0x00000000005ca2cc in instance_call.lto_priv () at
         ../Objects/classobject.c:2153
     #25 0x00000000004c9e8b in PyObject_Call (kw=<optimized out>,
         arg=<optimized out>, func=<optimized out>)
         at ../Objects/abstract.c:2529
     #26 do_call (nk=<optimized out>, na=<optimized out>, pp_stack=<optimized
         out>, func=<optimized out>)
         at ../Python/ceval.c:4251
     #27 call_function (oparg=<optimized out>, pp_stack=<optimized out>) at
         ../Python/ceval.c:4056
     #28 PyEval_EvalFrameEx () at ../Python/ceval.c:2679
     #29 0x00000000004e4518 in PyEval_EvalCodeEx (closure=<optimized out>,
         defcount=<optimized out>,
             defs=<optimized out>, kwcount=<optimized out>, kws=<optimized
             out>, argcount=<optimized out>,
                 args=<optimized out>, locals=<optimized out>,
                 globals=<optimized out>, co=<optimized out>)
         at ../Python/ceval.c:3265
     #30 function_call.lto_priv () at ../Objects/funcobject.c:526
     #31 0x0000000000502ab8 in PyObject_Call (kw=<optimized out>,
         arg=<optimized out>, func=<optimized out>)
         at ../Objects/abstract.c:2529
     #32 instancemethod_call.lto_priv () at ../Objects/classobject.c:2602
     #33 0x00000000004d0f2b in PyObject_Call (kw=<optimized out>, arg=(),
    
The segfault happens if no identity provider configurations could be found.
It seems that in the gctx_cleanup() function a pointer, instead of the actual
data, was recasted. That happened because the saml_glob_context_t struct was
given as a pointer to a pointer to the gctx_cleanup() function after reading
the identity provider configuration failed.
    
https://forge.univention.org/bugzilla/show_bug.cgi?id=39355